### PR TITLE
be kinder to phishtank by using a custom user-agent

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -123,7 +123,16 @@ func getPhishTankURLs() ([]PhishUrls, error) {
 		phishfeed = fmt.Sprintf("http://data.phishtank.com/data/%s/online-valid.json", apiKey)
 	}
 
-	resp, err := http.Get(phishfeed)
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", phishfeed, nil)
+	if err != nil {
+		return []PhishUrls{}, err
+	}
+
+	req.Header.Set("User-Agent", "kitphishr/1.0")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return []PhishUrls{}, err
 	}


### PR DESCRIPTION
Sets the UA when initially pulling the feed from PhishTank to `kitphishr/1.0` 

Their docs do state the format should be `phishtank/[username]` but using my username for other peoples apps doesn't feel quite right. Maybe I'll revisit, for now this is a reasonable trade-off.