### PR TITLE
Note that PhishTank account registration is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ or
 
 ## Configuration
 
-Kitphishr will work just fine right out of the box, but if you're going to be running this tool a lot then I suggest getting a [free API key from Phishtank](https://www.phishtank.com/api_register.php)
+Kitphishr will work just fine right out of the box, but if you're going to be running this tool a lot and you have access to a Phishtank account, then I suggest getting a [free API key from Phishtank](https://www.phishtank.com/api_register.php) (registration is currently disabled, so an existing account is required).
 
 Then, you can save this as an environment variable which Kitphishr will find and use:
 


### PR DESCRIPTION
To get an API key, an account is required, and registration is disabled:
![image](https://user-images.githubusercontent.com/84232764/232150996-67f6f925-3692-49a1-830b-39c4828601a9.png)
Unless I'm an idiot and there's another way to get an account, you'd need to have one from before they disabled registration.
This PR attempts to reword the sentence to make this known.

